### PR TITLE
Add tests for typing.Optional

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -133,6 +133,11 @@ def test_model_field_convert_to_type_union(typeless_model_field, value):
     assert typeless_model_field.convert_to_type(None, value, field_class=typing.Union[int, str]) is value
 
 
+@pytest.mark.parametrize('value', (1, None))
+def test_model_field_convert_to_type_optional(typeless_model_field, value):
+    assert typeless_model_field.convert_to_type(None, value, field_class=typing.Optional[int]) is value
+
+
 def test_model_field_convert_to_type_union_invalid(typeless_model_field):
     value = dict()
     with pytest.raises(AssertionError) as exc_info:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -460,6 +460,17 @@ def test_model_validate_union(default):
     assert type(union_model.union) == type(default)
 
 
+@pytest.mark.parametrize('default', (1, None))
+def test_model_validate_optional(default):
+    class OptionalModel(Model):
+        union: typing.Optional[int] = default
+
+    optional_model = OptionalModel()
+    optional_model.validate()
+    assert optional_model.union == default
+    assert type(optional_model.union) == type(default)
+
+
 def test_model_validate_and_clean_invalid_mocked_model(model):
     model.validate = mock.Mock(side_effect=ValidationError)
 


### PR DESCRIPTION
Since Optional is the same as `Union[x, None]` the support already exists, adding tests to make it explicit

fixes #23 